### PR TITLE
Add docker-compose to the project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  mysql-bookserver:
+    container_name: bookserver_mysql
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=1234
+      - MYSQL_USER=bookserver
+      - MYSQL_PASSWORD=1234
+      - MYSQL_DATABASE=bookserver
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:
+
+


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yml` file to the project, enabling easy setup of a MySQL database container for local development and testing.

Docker and MySQL setup:

* Added a `docker-compose.yml` file that defines a `mysql-bookserver` service using the latest MySQL image, with preconfigured environment variables for the root and user passwords, database name, and persistent storage using a Docker volume.