### PR TITLE
Add worktree to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ target/
 bin/
 build/
 src/main/webapp/assets/bower_components/
+worktree/
 .DS_Store


### PR DESCRIPTION
Enquanto estiver fazendo atualização dos projetos,  vai ser uma boa usar o git worktree.